### PR TITLE
fix mimesis 3 module renaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 3.5
   - 3.6
 
 install:

--- a/pytest_mimesis.py
+++ b/pytest_mimesis.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from mimesis.config import DEFAULT_LOCALE
+from mimesis.locales import DEFAULT_LOCALE
 from mimesis.schema import Field
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -3,7 +3,7 @@
 import string
 
 import pytest
-from mimesis.config import DEFAULT_LOCALE
+from mimesis.locales import DEFAULT_LOCALE
 
 
 def test_locale(mimesis_locale, mimesis):


### PR DESCRIPTION
* also dropped the unsupported python 3.5 travis config
* skipping 3.7 travis configuration obstacle for now