### PR TITLE
Update links after migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: python
 
 python:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 We use [`poetry`](https://github.com/sdispater/poetry) to manage the dependencies.
 
-To install them you would need to run two commands:
+To install them:
 
 ```bash
 poetry install
@@ -22,7 +22,7 @@ pytest
 To run linting:
 
 ```bash
-flake8 .
+flake8
 ```
 
 You can also run all checks for all python versions at once by:
@@ -51,4 +51,4 @@ Before submitting your code please do the following steps:
 You can contribute by spreading a word about this library.
 It would also be a huge contribution to write
 a short article on how you are using this project.
-What are your best-practices?
+What are your best practices?

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 [![Build Status](https://travis-ci.org/pytest-dev/pytest-mimesis.svg?branch=master)](https://travis-ci.org/pytest-dev/pytest-mimesis) [![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
 
-**pytest-mimesis** is a pytest plugin that provides pytest fixtures for [Mimesis](https://github.com/lk-geimfari/mimesis) providers.  This allows you to quickly and easily use randomized, dummy data as part of your test suite.
+**pytest-mimesis** is a pytest plugin that provides pytest fixtures for [Mimesis](https://github.com/lk-geimfari/mimesis) providers. This allows you to quickly and easily use randomized, dummy data as part of your test suite.
 
 
 ## Installation
 
-```
+```bash
 pip install pytest-mimesis
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## pytest-mimesis
 
 
-[![Build Status](https://travis-ci.org/mimesis-lab/pytest-mimesis.svg?branch=master)](https://travis-ci.org/mimesis-lab/pytest-mimesis) [![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
+[![Build Status](https://travis-ci.org/pytest-dev/pytest-mimesis.svg?branch=master)](https://travis-ci.org/pytest-dev/pytest-mimesis) [![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)
 
 **pytest-mimesis** is a pytest plugin that provides pytest fixtures for [Mimesis](https://github.com/lk-geimfari/mimesis) providers.  This allows you to quickly and easily use randomized, dummy data as part of your test suite.
 
@@ -58,4 +58,4 @@ test session, so creating new instances is cheap.
 
 ## License
 
-pytest-mimesis is licensed under the [MIT License](https://github.com/mimesis-lab/pytest-mimesis/blob/master/LICENSE).
+pytest-mimesis is licensed under the [MIT License](https://github.com/pytest-dev/pytest-mimesis/blob/master/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ authors = [
 
 readme = "README.md"
 
-repository = "https://github.com/mimesis-lab/pytest-mimesis"
-homepage = "https://github.com/mimesis-lab/pytest-mimesis"
+repository = "https://github.com/pytest-dev/pytest-mimesis"
+homepage = "https://github.com/pytest-dev/pytest-mimesis"
 
 keywords = [
   "mimesis",


### PR DESCRIPTION
Fixes #74.

Also:

* `sudo` is no longer needed on Travis CI
  * https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
* Adjust some wording and formatting
